### PR TITLE
Added simple support for 'assert forms (they are java.lang.Errors, not

### DIFF
--- a/src/test/clojure/clojure/tools/test_trace.clj
+++ b/src/test/clojure/clojure/tools/test_trace.clj
@@ -45,6 +45,10 @@
   (is (thrown-with-msg? ArithmeticException #"Divide by zero\n  Form failed: \(/ 3 0\)\n  Form failed: \{:a 1, :b \(/ 3 0\)\}"
                         (trace-forms {:a 1 :b (/ 3 0)}))))
 
+(deftest test-assert
+  (is (thrown-with-msg? AssertionError #"Assert failed: \(\= 2 3\)\n  Form failed: \(assert \(\= 2 3\)\)"
+                        (trace-forms (assert (= 2 3))))))
+
 (def trace-ns-test-namespace (create-ns 'trace.test.namesp))
 
 (binding [*ns* trace-ns-test-namespace]


### PR DESCRIPTION
Added simple support for `assert` forms. They raise `java.lang.AssertionError` instances instead of `Exception` ones (both classes derives from `Throwable`), so before this patch `trace-forms` didn't catched them.
