### PR TITLE
Do not trace vars if already traced

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,7 @@ local.properties
 # leinigen
 .lein-deps-sum
 .lein-failures
+.lein-repl-history
 lib/**
 
 /bin

--- a/src/main/clojure/clojure/tools/trace.clj
+++ b/src/main/clojure/clojure/tools/trace.clj
@@ -126,7 +126,7 @@ such as clojure.core/+"
                                   (trace-fn-call '~fname f# args#)))))]
      ~@exprs))
 
-(declare trace-form)
+(declare trace-form traced?)
 (defmulti trace-special-form (fn [form] (first form)))
 
 (defn ^{:private true} trace-bindings
@@ -327,7 +327,8 @@ such as clojure.core/+"
      (let [^clojure.lang.Var v (if (var? v) v (resolve v))
            ns (.ns v)
            s  (.sym v)]
-       (if (and (ifn? @v) (-> v meta :macro not))
+       (if (and (ifn? @v) (-> v meta :macro not)
+                          (not (traced? v)))
          (let [f @v
                vname (symbol (str ns "/" s))]
            (doto v

--- a/src/test/clojure/clojure/tools/test_trace.clj
+++ b/src/test/clojure/clojure/tools/test_trace.clj
@@ -88,6 +88,15 @@
   (untrace-ns trace-ns-test-namespace)
   (is (= (cleanup (with-out-str (trace.test.namesp/bar))) "")))
 
+(deftest trace-applies-once
+  (trace-vars trace.test.namesp/bar)
+  (trace-vars trace.test.namesp/bar)
+  (is (= (cleanup (with-out-str (trace.test.namesp/bar)))
+         "TRACE t:# (trace.test.namesp/bar)|TRACE t:# => :foo|"))
+  (untrace-ns trace-ns-test-namespace)
+  (is (with-out-str (trace.test.namesp/bar)) "")
+  (is (not (traced? 'trace.test.namesp/bar))))
+
 (deftest istraced
   (is (not (traced? 'trace.test.namesp/bar)))
   (trace-vars trace.test.namesp/bar)


### PR DESCRIPTION
Calling `trace-var*` several times, `untrace-var*` removes only the highest level of tracing.
`trace-var*` should be a noop when called for an already traced var.