### PR TITLE
Uncomment code incompatible with Java 5

### DIFF
--- a/src/main/clojure/clojure/tools/trace.clj
+++ b/src/main/clojure/clojure/tools/trace.clj
@@ -245,22 +245,19 @@ such as clojure.core/+"
           :else this))
       (catch Exception e# this))))
 
-;; The following should be re-enabled when Java 5 support is dropped.
-
-;(extend-type java.io.IOError
-;  ThrowableRecompose
-;  (clone-throwable [this stack-trace args] 
-;    (try
-;      (let [ctor (.getConstructor java.io.IOError (into-array [java.lang.Throwable]))
-;            arg (first args)]
-;        (cond
-;          (instance? java.lang.Throwable (first arg))
-;          (doto (.newInstance ctor (into-array [arg])) (.setStackTrace stack-trace))
-;          
-;          (string? arg)
-;          (doto (.newInstance ctor (into-array [(Throwable. arg)])) (.setStackTrace stack-trace))
-;          :else this))
-;      (catch Exception e# this))))  
+(extend-type java.io.IOError
+  ThrowableRecompose
+  (clone-throwable [this stack-trace args] 
+    (try
+      (let [ctor (.getConstructor java.io.IOError (into-array [java.lang.Throwable]))
+            arg (first args)]
+        (cond
+          (instance? java.lang.Throwable (first arg))
+          (doto (.newInstance ctor (into-array [arg])) (.setStackTrace stack-trace))
+          (string? arg)
+          (doto (.newInstance ctor (into-array [(Throwable. arg)])) (.setStackTrace stack-trace))
+          :else this))
+      (catch Exception e# this))))
 
 (extend-type java.lang.ThreadDeath
   ThrowableRecompose


### PR DESCRIPTION
Support for Java 5 is dropped since Clojure 1.6