### PR TITLE
Add fake k-v style argument for fn trace

### DIFF
--- a/src/main/clojure/clojure/tools/trace.clj
+++ b/src/main/clojure/clojure/tools/trace.clj
@@ -81,7 +81,10 @@ affecting the result."
   ([value] (trace nil value))
   ([name value]
      (tracer name (pr-str value))
-     value))
+     value)
+  ([value name-k name]
+     (assert (= :name name-k))
+     (trace name value)))
 
 (defn ^{:private true} trace-indent
   "Returns an indentation string based on *trace-depth*"


### PR DESCRIPTION
Add a fake k-v style argument for trace, like:
``` clojure
(trace a-value :name "my-value")
```

For `thread-first` macro:
``` clojure
;; current
(->> value-to-trace
         trace
         (trace "my-value"))

;; new-added
(-> value-to-trace
      (trace :name "my-value"))
```

Maybe there is a better way? 👀 